### PR TITLE
Update revel to 404 in case of an invalid directory

### DIFF
--- a/modules/static/app/controllers/static.go
+++ b/modules/static/app/controllers/static.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	fpath "path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/yext/glog"
 	"github.com/yext/revel"
@@ -59,7 +60,7 @@ func (c Static) Serve(prefix, filepath string) revel.Result {
 
 	finfo, err := os.Stat(fname)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) || err.(*os.PathError).Err == syscall.ENOTDIR {
 			glog.Warningf("File not found (%s): %s ", fname, err)
 			return c.NotFound("File not found")
 		}


### PR DESCRIPTION
Previously, "file not found" errors would correctly be treated as a 404, but "Not a directory" errors would get a 500.

As a simple example, if `public/foo.js` is being served, `public/foo.js/bar.txt` would give a 500.

This is undesirable because it spams our error logs if a bad actor (or a typo) starts hitting us with requests.

This fix has been in the official revel fork since 2013, and I essentially just copied their change.
Source: https://github.com/revel/revel/pull/402

TEST=compile