### PR TITLE
Update fixed param priority

### DIFF
--- a/params.go
+++ b/params.go
@@ -94,20 +94,27 @@ func (p *Params) calcValues() url.Values {
 		return p.Form
 	}
 
-	// Copy everything into the same map.
+	// Copy everything into a param map,
+	// order of priority is least to most trusted
 	values := make(url.Values, numParams)
+
+	// ?query vars first
 	for k, v := range p.Query {
 		values[k] = append(values[k], v...)
 	}
-	for k, v := range p.Fixed {
-		values[k] = append(values[k], v...)
-	}
-	for k, v := range p.Route {
-		values[k] = append(values[k], v...)
-	}
+	// form vars overwrite
 	for k, v := range p.Form {
 		values[k] = append(values[k], v...)
 	}
+	// :/path vars overwrite
+	for k, v := range p.Route {
+		values[k] = append(values[k], v...)
+	}
+	// fixed vars overwrite
+	for k, v := range p.Fixed {
+		values[k] = append(values[k], v...)
+	}
+
 	return values
 }
 


### PR DESCRIPTION
Applies the patch from https://github.com/revel/revel/pull/1126/files which blocks users from applying a malicious prefix by overriding the default value ("public" for our systems).

Tested against our WidgetsServing app to verify the "public" prefix is respected, and users cannot use a query param to cheat the restriction (ie: "?prefix=../../../../secretfile.txt").