### PR TITLE
Revel: change param priority, take 2

### DIFF
--- a/params.go
+++ b/params.go
@@ -98,21 +98,24 @@ func (p *Params) calcValues() url.Values {
 	// order of priority is least to most trusted
 	values := make(url.Values, numParams)
 
-	// ?query vars first
+	// ?query vars are first
 	for k, v := range p.Query {
 		values[k] = append(values[k], v...)
 	}
-	// form vars overwrite
+
+	// form vars append so query first, form second
 	for k, v := range p.Form {
 		values[k] = append(values[k], v...)
 	}
-	// :/path vars overwrite
+
+	// :/path vars overwrite and any above variables over written with path
 	for k, v := range p.Route {
-		values[k] = append(values[k], v...)
+		values[k] = v
 	}
-	// fixed vars overwrite
+
+	// fixed vars overwrite, finaly rewrite all above values with the fixed ones
 	for k, v := range p.Fixed {
-		values[k] = append(values[k], v...)
+		values[k] = v
 	}
 
 	return values


### PR DESCRIPTION
Per the issue linked below, the previous change was insufficient for proper security. This fixes the priority entirely by having fixed params fully override query params, rather than appending.

https://github.com/revel/revel/pull/1155#issuecomment-291635366

Tested against our Revel-using services locally to verify they now fully block any malicious attempts to access files outside the fixed path.